### PR TITLE
Fix gtest dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/gtest"]
 	path = third_party/gtest
-	url = git@github.com:google/googletest.git
+	url = https://github.com/google/googletest.git

--- a/pyaff4/pyaff4/data_store.py
+++ b/pyaff4/pyaff4/data_store.py
@@ -303,7 +303,7 @@ class MemoryDataStore(object):
 
     def LoadFromTurtle(self, stream):
         data = stream.read(1000000)
-        print data
+        #print data
         g = rdflib.Graph()
         g.parse(data=data, format="turtle")
 


### PR DESCRIPTION
Enable pulling gtest dependency more easily. 
Disable debugging print