### PR TITLE
Add missing include that leads to build failure using GCC-7

### DIFF
--- a/src/aff4_registry.h
+++ b/src/aff4_registry.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <iostream>
+#include <functional>
 
 //using std::string;
 //using std::unique_ptr;


### PR DESCRIPTION
See <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=853300>,
<http://people.debian.org/~doko/logs/gcc7-20170126/aff4_0.24.post1-2_unstable_gcc7.log>