### PR TITLE
add new dependency SPARQLWrapper

### DIFF
--- a/pyaff4/setup.py
+++ b/pyaff4/setup.py
@@ -59,7 +59,8 @@ setup(
         "rdflib == 4.2.1",
         "intervaltree == 2.1.0",
         "pyblake2 == 0.9.3",
-        "expiringdict == 1.1.4"
+        "expiringdict == 1.1.4",
+        "SPARQLWrapper == 1.8.0",
     ],
     extras_require=dict(
         cloud="google-api-python-client"


### PR DESCRIPTION
`SPARQLWrapper` is needed when loading `aff4.py` in `rekall-core`:

~~~
  File "/home/.../rekall3_test/rekall/rekall-core/rekall/plugins/addrspaces/__init__.py", line 41, in <module>
    import rekall.plugins.addrspaces.aff4
  File "/home/.../rekall3_test/rekall/rekall-core/rekall/plugins/addrspaces/aff4.py", line 410, in <module>
    import rdflib.plugins.stores.sparqlstore
  File "/home/.../rekall3_test/venv/lib/python3.5/site-packages/rdflib-4.2.1-py3.5.egg/rdflib/plugins/stores/sparqlstore.py", line 24, in <module>
    "Install with 'easy_install SPARQLWrapper'")
Exception: SPARQLWrapper not found! SPARQL Store will not work.Install with 'easy_install SPARQLWrapper'

~~~