### PR TITLE
fix dependency on SPARQLWrapper

### DIFF
--- a/pyaff4/setup.py
+++ b/pyaff4/setup.py
@@ -56,7 +56,7 @@ setup(
     package_dir={"pyaff4": "pyaff4"},
     install_requires=[
         "aff4-snappy == 0.5",
-        "rdflib == 4.2.1",
+        "rdflib[sparql] == 4.2.2",
         "intervaltree == 2.1.0",
         "pyblake2 == 0.9.3",
         "expiringdict == 1.1.4"


### PR DESCRIPTION
This fixes the dependency we have on SPARQLWrapper, by specifying  that we need the extra `sparql` on the `rdflib` dependency.

`rdflib` extra: https://github.com/RDFLib/rdflib/blob/master/setup.py#L11

`rekall` `SPARQLWrapper` dependency: https://github.com/google/rekall/blob/master/rekall-core/rekall/plugins/addrspaces/aff4.py#L408