### PR TITLE
fix magic string in python3

### DIFF
--- a/pyaff4/pyaff4/zip.py
+++ b/pyaff4/pyaff4/zip.py
@@ -55,7 +55,7 @@ class EndCentralDirectory(struct_parser.CreateStruct(
         uint16_t comment_len = 0;
         """)):
 
-    magic_string = 'PK\x05\x06'
+    magic_string = b'PK\x05\x06'
 
     def IsValid(self):
         return self.magic == 0x6054b50


### PR DESCRIPTION
This fixes the search in `zip.py`:

~~~
  File "/home/tarrma/Bureau/rekall3_test/venv/lib/python3.5/site-packages/pyaff4-0.24.post3-py3.5.egg/pyaff4/zip.py", line 431, in parse_cd
    end_cd, buffer_offset = EndCentralDirectory.FromBuffer(buffer)
  File "/home/tarrma/Bureau/rekall3_test/venv/lib/python3.5/site-packages/pyaff4-0.24.post3-py3.5.egg/pyaff4/zip.py", line 71, in FromBuffer
    index = buffer.rfind(cls.magic_string, 0, end)
TypeError: a bytes-like object is required, not 'str'
~~~